### PR TITLE
chore: upgrade node version and dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Set up Node.js 20.x (GitHub npm registry)
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://npm.pkg.github.com/
           scope: "@alismx"
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --prod
       - name: Generate client
-        run: npm run build
+        run: pnpm run build
       - name: Publish package
-        run: npm publish
+        run: pnpm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@alismx/gitmsg",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Use openai to generate commit messages from a diff",
   "main": "index.js",
   "devDependencies": {
-    "@types/minimist": "^1.2.2",
-    "@types/node": "^18.16.3",
-    "minimist": "^1.2.8",
-    "prettier": "^2.8.8",
-    "typescript": "^5.7.3"
+    "@types/node": "^18.19.74",
+    "prettier": "^2.8.8"
   },
   "dependencies": {
-    "openai": "^4.80.0"
+    "openai": "^4.82.0",
+    "minimist": "^1.2.8",
+    "typescript": "^5.7.3",
+    "@types/minimist": "^1.2.5"
   },
   "scripts": {
     "build": "npx tsc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,25 +8,25 @@ importers:
 
   .:
     dependencies:
-      openai:
-        specifier: ^4.80.0
-        version: 4.81.0
-    devDependencies:
       '@types/minimist':
-        specifier: ^1.2.2
+        specifier: ^1.2.5
         version: 1.2.5
-      '@types/node':
-        specifier: ^18.16.3
-        version: 18.19.74
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
-      prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+      openai:
+        specifier: ^4.82.0
+        version: 4.82.0
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+    devDependencies:
+      '@types/node':
+        specifier: ^18.19.74
+        version: 18.19.74
+      prettier:
+        specifier: ^2.8.8
+        version: 2.8.8
 
 packages:
 
@@ -103,8 +103,8 @@ packages:
       encoding:
         optional: true
 
-  openai@4.81.0:
-    resolution: {integrity: sha512-lXkFkV+He3O6RGnldHncRGef4uWHssDsAVwN5I3bWcgIdDPy/w8vgtIAwvZxAj49m4WiwWVD0+eGTJ9xOv/ISA==}
+  openai@4.82.0:
+    resolution: {integrity: sha512-1bTxOVGZuVGsKKUWbh3BEwX1QxIXUftJv+9COhhGGVDTFwiaOd4gWsMynF2ewj1mg6by3/O+U8+EEHpWRdPaJg==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -205,7 +205,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  openai@4.81.0:
+  openai@4.82.0:
     dependencies:
       '@types/node': 18.19.74
       '@types/node-fetch': 2.6.12


### PR DESCRIPTION
## Changes Proposed 

This PR updates the GitHub Actions workflow, package.json file, and lockfile used for creating an automatic commit message generator. The main goal is to enhance efficiency and improve the versioning system.

_Note_: The change in version '0.0.1' to '0.0.2'.

## Additional Information 

- The node version was upgraded from 20.x to 22.x.
- Dependencies were also updated, including the 'openai' package, typescript, and other packages.
- The command to install dependencies changed from 'npm ci' to 'pnpm install --prod', and the command to generate the client and to publish the package changed from 'npm' to 'pnpm'. This was done because 'pnpm' is usually faster and more efficient than 'npm'.