### PR TITLE
feat: add pnpm setup step in GitHub actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ jobs:
           node-version: 22.x
           registry-url: https://npm.pkg.github.com/
           scope: "@alismx"
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - name: Install dependencies
         run: pnpm install --prod
       - name: Generate client


### PR DESCRIPTION
## Changes Proposed

- A new job has been added to our GitHub workflow to setup pnpm, using a public GitHub Action `pnpm/action-setup@v4`, and specifying version 9.